### PR TITLE
Give the GitHub actions workflow a formal name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+name: tests
 on: push
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # c14n
 
  [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/ucarion/c14n?tab=overview)
- ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ucarion/c14n/tests?label=tests&logo=github&style=flat-square)
+ [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ucarion/c14n/tests?label=tests&logo=github&style=flat-square)](https://github.com/ucarion/c14n/actions)
 
 This package is a Golang implementation of XML Canonicalization ("c14n"). In
 particular, it implements the [Exclusive Canonical XML][w3] specification, which

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # c14n
 
  [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/ucarion/c14n?tab=overview)
+ ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ucarion/c14n/tests?label=tests&logo=github&style=flat-square)
 
 This package is a Golang implementation of XML Canonicalization ("c14n"). In
 particular, it implements the [Exclusive Canonical XML][w3] specification, which


### PR DESCRIPTION
This PR gives the GitHub actions workflow a formal name, which lets us add a badge that shows its status.